### PR TITLE
Add Asyncify backend for emscripten (upstream LLVM only)

### DIFF
--- a/koishi_test.c
+++ b/koishi_test.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <assert.h>
+#include <string.h>
 
 void *cofunc1(void *data) {
 	assert(koishi_state(koishi_active()) == KOISHI_RUNNING);
@@ -61,6 +62,7 @@ void test1(koishi_coroutine_t *c) {
 	printf("O: resume 1\n");
 	str = koishi_resume(c, "Hello");
 	printf("O: post yield 1 (got %s)\n", str);
+	assert(!strcmp(str, "Reimu"));
 }
 
 void test2(koishi_coroutine_t *c) {
@@ -91,9 +93,11 @@ int main(int argc, char **argv) {
 	printf("O: resume 2\n");
 	str = koishi_resume(c, "Hakurei");
 	printf("O: post yield 2 (got %s)\n", str);
+	assert(!strcmp(str, "Marisa"));
 	printf("O: resume 3\n");
 	str = koishi_resume(c, "Kirisame");
 	printf("O: post yield 3 (got %s)\n", str);
+	assert(!strcmp(str, "Youmu"));
 	printf("O: resume 4\n");
 	str = koishi_resume(c, "Konpaku");
 	printf("O: done (got %s)\n", str);

--- a/meson.build
+++ b/meson.build
@@ -12,6 +12,7 @@ soversion = meson.project_version()
 os = host_machine.system()
 arch = host_machine.cpu_family()
 os_is_windows = (os == 'windows' or os == 'uwp' or os == 'cygwin')
+os_is_emscripten = (os == 'emscripten')
 
 cc = meson.get_compiler('c')
 
@@ -98,11 +99,16 @@ koishi_args += ['-DBUILDING_KOISHI']
 koishi_args += feature_args
 koishi_args += warn_args
 
+koishi_external_args = []
+koishi_external_link_args = []
+
 subdir('src')
 
 koishi_dep = declare_dependency(
     include_directories : koishi_incdirs,
     link_with : libkoishi,
+    compile_args : koishi_external_args,
+    link_args : koishi_external_link_args,
 )
 
 if not meson.is_subproject()
@@ -118,7 +124,8 @@ if not meson.is_subproject()
         filebase : meson.project_name(),
         description : 'Decently portable C11 coroutine library',
         subdirs : meson.project_name(),
-        libraries : libkoishi,
+        libraries : [libkoishi, koishi_external_link_args],
         version : meson.project_version(),
+        extra_cflags : koishi_external_args,
     )
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,7 +1,7 @@
 option(
     'impl',
     type : 'combo',
-    choices : ['auto', 'fcontext', 'win32fiber', 'emscripten', 'ucontext'],
+    choices : ['auto', 'fcontext', 'win32fiber', 'emscripten', 'ucontext', 'asyncify'],
     description : 'Which implementation to use'
 )
 

--- a/src/asyncify/asyncify.c
+++ b/src/asyncify/asyncify.c
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 
-typedef intptr_t fiber_handle_t;
+typedef void *fiber_handle_t;
 
 typedef struct asyncify_fiber {
 	fiber_handle_t handle;
@@ -14,7 +14,8 @@ typedef struct asyncify_fiber {
 
 #include "../fiber.h"
 
-fiber_handle_t _koishi_impl_fiber_create(void (*entry)(void));
+fiber_handle_t _koishi_impl_fiber_create(size_t stack_size, void (*entry)(void));
+fiber_handle_t _koishi_impl_fiber_create_for_main_ctx(void);
 void _koishi_impl_fiber_recycle(fiber_handle_t fiber, void (*entry)(void));
 void _koishi_impl_fiber_free(fiber_handle_t fiber);
 void _koishi_impl_fiber_swap(fiber_handle_t old, fiber_handle_t new);
@@ -27,8 +28,8 @@ KOISHI_NORETURN static void co_entry(void) {
 }
 
 static void koishi_fiber_init(koishi_fiber_t *fiber, size_t min_stack_size, koishi_entrypoint_t entry_point) {
-	(void)min_stack_size;
-	fiber->handle = _koishi_impl_fiber_create(co_entry);
+	size_t stack_size = koishi_util_real_stack_size(min_stack_size);
+	fiber->handle = _koishi_impl_fiber_create(stack_size, co_entry);
 	assert(fiber->handle != 0);
 	fiber->entry = entry_point;
 }
@@ -41,7 +42,7 @@ static void koishi_fiber_deinit(koishi_fiber_t *fiber) {
 }
 
 static void koishi_fiber_init_main(koishi_fiber_t *fiber) {
-	fiber->handle = _koishi_impl_fiber_create(abort);
+	fiber->handle = _koishi_impl_fiber_create_for_main_ctx();
 }
 
 static void koishi_fiber_recycle(koishi_fiber_t *fiber, koishi_entrypoint_t entry_point) {

--- a/src/asyncify/asyncify.c
+++ b/src/asyncify/asyncify.c
@@ -1,0 +1,54 @@
+
+#include <koishi.h>
+#include <emscripten.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+typedef intptr_t fiber_handle_t;
+
+typedef struct asyncify_fiber {
+	fiber_handle_t handle;
+	koishi_entrypoint_t entry;
+} koishi_fiber_t;
+
+#include "../fiber.h"
+
+fiber_handle_t _koishi_impl_fiber_create(void (*entry)(void));
+void _koishi_impl_fiber_recycle(fiber_handle_t fiber, void (*entry)(void));
+void _koishi_impl_fiber_free(fiber_handle_t fiber);
+void _koishi_impl_fiber_swap(fiber_handle_t old, fiber_handle_t new);
+
+KOISHI_NORETURN static void co_entry(void) {
+	koishi_coroutine_t *co = co_current;
+	co->userdata = co->fiber.entry(co->userdata);
+	koishi_swap_coroutine(co, co->caller, KOISHI_DEAD);
+	KOISHI_UNREACHABLE;
+}
+
+static void koishi_fiber_init(koishi_fiber_t *fiber, size_t min_stack_size, koishi_entrypoint_t entry_point) {
+	(void)min_stack_size;
+	fiber->handle = _koishi_impl_fiber_create(co_entry);
+	assert(fiber->handle != 0);
+	fiber->entry = entry_point;
+}
+
+static void koishi_fiber_deinit(koishi_fiber_t *fiber) {
+	if(fiber->handle) {
+		_koishi_impl_fiber_free(fiber->handle);
+		fiber->handle = 0;
+	}
+}
+
+static void koishi_fiber_init_main(koishi_fiber_t *fiber) {
+	fiber->handle = _koishi_impl_fiber_create(abort);
+}
+
+static void koishi_fiber_recycle(koishi_fiber_t *fiber, koishi_entrypoint_t entry_point) {
+	_koishi_impl_fiber_recycle(fiber->handle, co_entry);
+	fiber->entry = entry_point;
+}
+
+static void koishi_fiber_swap(koishi_fiber_t *from, koishi_fiber_t *to) {
+	_koishi_impl_fiber_swap(from->handle, to->handle);
+}

--- a/src/asyncify/library_fiber.js
+++ b/src/asyncify/library_fiber.js
@@ -1,55 +1,92 @@
 
 mergeInto(LibraryManager.library, {
-
 	$Fibers: {
-		live: [], swapCounter: 0,
-
-		allocate: function(obj) {
-			var id = this.live.length + 1;
-			this.live[id] = obj;
-			return id;
-		},
-
-		free: function(id) {
-			delete this.live[id];
-		},
-
-		get: function(id) {
-			return this.live[id];
-		}
+		swapCounter: 0,
+		continuations: {},
 	},
 
-	_koishi_impl_fiber_create__deps: ["$Fibers"],
-	_koishi_impl_fiber_create: function(funcptr) {
-		return Fibers.allocate({
-			jump: () => {{{ makeDynCall('v') }}}(funcptr),
-			state: null,
-		});
+	/*
+	 * Layout of an ASYNCIFY fiber structure
+	 *
+	 *  0 Asyncify context
+	 *  4 Stack pointer
+	 *  8 Stack max
+	 * 12 Stack:
+	 *    ...
+	 */
+	_koishi_impl_fiber_create__deps: ['$Fibers', 'malloc'],
+	_koishi_impl_fiber_create: function(stack_size, funcptr) {
+		stack_size = stack_size|0;
+		funcptr = funcptr|0;
+		var fib = _malloc(stack_size + 12 | 0) | 0;
+
+		// init Asyncify context to null
+		{{{ makeSetValueAsm('fib', 0, 0, 'i32') }}};
+
+		// init stack pointer
+		{{{ makeSetValueAsm('fib', 4, '(fib+stack_size+12)', 'i32') }}};
+
+		// init STACK_MAX
+		{{{ makeSetValueAsm('fib', 8, '(fib+12)', 'i32') }}};
+
+		// init continuation (call user-supplied function)
+		Fibers.continuations[fib] = () => {
+#if STACK_OVERFLOW_CHECK
+			writeStackCookie();
+#endif
+			{{{ makeDynCall('v') }}}(funcptr);
+		};
+
+		return fib|0;
+	},
+
+	_koishi_impl_fiber_create__deps: ['$Fibers', 'malloc'],
+	_koishi_impl_fiber_create_for_main_ctx: function() {
+		var fib = _malloc(12) | 0;
+		{{{ makeSetValueAsm('fib', 8, 'STACK_MAX', 'i32') }}};
+		return fib|0;
 	},
 
 	_koishi_impl_fiber_recycle__deps: ["$Fibers"],
-	_koishi_impl_fiber_recycle: function(id, funcptr) {
-		var fib = Fibers.get(id);
-		fib.jump = () => {{{ makeDynCall('v') }}}(funcptr);
-		fib.state = null;
+	_koishi_impl_fiber_recycle: function(fib, funcptr) {
+		{{{ makeSetValueAsm('fib', 0, 0, 'i32') }}};
+		{{{ makeSetValueAsm('fib', 8, '(fib+12)', 'i32') }}};
+		Fibers.continuations[fib] = () => {{{ makeDynCall('v') }}}(funcptr);
 	},
 
-	_koishi_impl_fiber_free__deps: ["$Fibers"],
-	_koishi_impl_fiber_free: function(id) {
-		Fibers.free(id);
+	_koishi_impl_fiber_free__deps: ["$Fibers", "free"],
+	_koishi_impl_fiber_free: function(fib) {
+		delete Fibers.continuations[fib];
+		_free(fib);
 	},
 
 	_koishi_impl_fiber_swap__deps: ["$Fibers"],
-	_koishi_impl_fiber_swap: function(id_old, id_new) {
-		var f_old = Fibers.get(id_old);
-		var f_new = Fibers.get(id_new);
+	_koishi_impl_fiber_swap: function(f_old, f_new) {
 
 		return Asyncify.handleSleep((wakeUp) => {
 			var swap = () => {
-				f_old.jump = wakeUp;
-				f_old.state = Asyncify.currData;
-				Asyncify.currData = f_new.state;
-				f_new.jump();
+				// update asyncify context for caller
+				var asyncify_context = Asyncify.currData;
+				{{{ makeSetValueAsm('f_old', 0, 'asyncify_context', 'i32') }}};
+
+				// update stack pointer for caller
+				var stack_ptr = stackSave() | 0;
+				{{{ makeSetValueAsm('f_old', 4, 'stack_ptr', 'i32') }}};
+
+				// update continuation for caller
+				Fibers.continuations[f_old] = wakeUp;
+
+				// load asyncify context from callee
+				Asyncify.currData = {{{ makeGetValueAsm('f_new', 0, 'i32') }}};
+
+				// load stack pointer from callee
+				stack_ptr = {{{ makeGetValueAsm('f_new', 4, 'i32') }}};
+				stackRestore(stack_ptr);
+
+				// load STACK_MAX from callee
+				STACK_MAX = {{{ makeGetValueAsm('f_new', 8, 'i32') }}};
+
+				Fibers.continuations[f_new]();
 			};
 
 			if(Fibers.swapCounter == 1000) {
@@ -61,5 +98,5 @@ mergeInto(LibraryManager.library, {
 				Asyncify.afterUnwind = swap;
 			}
 		});
-	}
+	},
 });

--- a/src/asyncify/library_fiber.js
+++ b/src/asyncify/library_fiber.js
@@ -1,0 +1,65 @@
+
+mergeInto(LibraryManager.library, {
+
+	$Fibers: {
+		live: [], swapCounter: 0,
+
+		allocate: function(obj) {
+			var id = this.live.length + 1;
+			this.live[id] = obj;
+			return id;
+		},
+
+		free: function(id) {
+			delete this.live[id];
+		},
+
+		get: function(id) {
+			return this.live[id];
+		}
+	},
+
+	_koishi_impl_fiber_create__deps: ["$Fibers"],
+	_koishi_impl_fiber_create: function(funcptr) {
+		return Fibers.allocate({
+			jump: () => {{{ makeDynCall('v') }}}(funcptr),
+			state: null,
+		});
+	},
+
+	_koishi_impl_fiber_recycle__deps: ["$Fibers"],
+	_koishi_impl_fiber_recycle: function(id, funcptr) {
+		var fib = Fibers.get(id);
+		fib.jump = () => {{{ makeDynCall('v') }}}(funcptr);
+		fib.state = null;
+	},
+
+	_koishi_impl_fiber_free__deps: ["$Fibers"],
+	_koishi_impl_fiber_free: function(id) {
+		Fibers.free(id);
+	},
+
+	_koishi_impl_fiber_swap__deps: ["$Fibers"],
+	_koishi_impl_fiber_swap: function(id_old, id_new) {
+		var f_old = Fibers.get(id_old);
+		var f_new = Fibers.get(id_new);
+
+		return Asyncify.handleSleep((wakeUp) => {
+			var swap = () => {
+				f_old.jump = wakeUp;
+				f_old.state = Asyncify.currData;
+				Asyncify.currData = f_new.state;
+				f_new.jump();
+			};
+
+			if(Fibers.swapCounter == 1000) {
+				Fibers.swapCounter = 0;
+				Asyncify.afterUnwind = null;
+				setTimeout(swap);
+			} else {
+				Fibers.swapCounter++;
+				Asyncify.afterUnwind = swap;
+			}
+		});
+	}
+});

--- a/src/asyncify/meson.build
+++ b/src/asyncify/meson.build
@@ -1,0 +1,7 @@
+
+asyncify_supported = os_is_emscripten
+
+asyncify_src = files('asyncify.c')
+asyncify_args = ['-s', 'ASYNCIFY']
+asyncify_external_args = ['-s', 'ASYNCIFY']
+asyncify_external_link_args = ['-s', 'ASYNCIFY', '--js-library', join_paths(meson.current_source_dir(), 'library_fiber.js')]

--- a/src/emscripten/meson.build
+++ b/src/emscripten/meson.build
@@ -13,3 +13,5 @@ endif
 
 emscripten_src = files('emscripten.c')
 emscripten_args = []
+emscripten_external_args = []
+emscripten_external_link_args = []

--- a/src/fcontext/meson.build
+++ b/src/fcontext/meson.build
@@ -75,3 +75,5 @@ foreach routine : fcontext_asm_routines
 endforeach
 
 fcontext_args = ['-DFCONTEXT_CALL=@0@'.format(fcontext_callconv)]
+fcontext_external_args = []
+fcontext_external_link_args = []

--- a/src/meson.build
+++ b/src/meson.build
@@ -3,7 +3,13 @@ koishi_src = files(
     'stack_alloc.c',
 )
 
-backends = ['fcontext', 'win32fiber', 'emscripten', 'ucontext']
+backends = [
+    'fcontext',
+    'win32fiber',
+    'asyncify',
+    'emscripten',
+    'ucontext',
+]
 
 foreach i : backends
     subdir(i)
@@ -28,6 +34,8 @@ endif
 
 koishi_src += get_variable('@0@_src'.format(impl))
 koishi_args += get_variable('@0@_args'.format(impl))
+koishi_external_args += get_variable('@0@_external_args'.format(impl))
+koishi_external_link_args += get_variable('@0@_external_link_args'.format(impl))
 
 message('Using the @0@ backend'.format(impl))
 

--- a/src/ucontext/meson.build
+++ b/src/ucontext/meson.build
@@ -13,3 +13,5 @@ endif
 
 ucontext_src = files('ucontext.c')
 ucontext_args = []
+ucontext_external_args = []
+ucontext_external_link_args = []

--- a/src/win32fiber/meson.build
+++ b/src/win32fiber/meson.build
@@ -3,3 +3,5 @@ win32fiber_supported = os_is_windows
 
 win32fiber_src = files('win32fiber.c')
 win32fiber_args = []
+win32fiber_external_args = []
+win32fiber_external_link_args = []


### PR DESCRIPTION
Unlike the 'emscripten' backend, this one doesn't use the emscripten coroutines API (which is currently broken) and instead implements a minimal context-switching "fiber" API as a JS library on top of Asyncify. See emscripten-core/emscripten#8979 for more details.

`_koishi_impl_fiber_swap` must be manually added to `ASYNCIFY_IMPORTS` by the user of the library, because emcc does not provide a way to append to the imports array without completely overwriting it yet.