### PR TITLE
Elbrus support and minor fixes

### DIFF
--- a/koishi_test.c
+++ b/koishi_test.c
@@ -97,7 +97,7 @@ void cancelled_caller_test(int *result) {
 	koishi_coroutine_t inner, outer;
 	koishi_init(&inner, 0, cancelled_caller_test_inner);
 	koishi_init(&outer, 0, cancelled_caller_test_outer);
-	*result = (int)koishi_resume(&outer, &inner);
+	*result = (intptr_t)koishi_resume(&outer, &inner);
 }
 
 int main(int argc, char **argv) {

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,6 @@
 project('koishi', 'c',
     version : '0.1',
+    meson_version : '>=0.48.0',
     default_options : [
         'c_std=c11',
         'default_library=both',

--- a/src/fcontext/fcontext.c
+++ b/src/fcontext/fcontext.c
@@ -32,7 +32,7 @@ static void koishi_fiber_swap(koishi_fiber_t *from, koishi_fiber_t *to) {
 	from->fctx = tf.fctx;
 }
 
-KOISHI_NORETURN static void co_entry(transfer_t tf) {
+static KOISHI_NORETURN void co_entry(transfer_t tf) {
 	koishi_coroutine_t *co = co_current;
 	assert(tf.data == &co->caller->fiber);
 	((koishi_fiber_t*)tf.data)->fctx = tf.fctx;

--- a/src/fiber.h
+++ b/src/fiber.h
@@ -61,7 +61,7 @@ static void koishi_return_to_caller(koishi_coroutine_t *from, int state) {
 	koishi_swap_coroutine(from, from->caller, state);
 }
 
-KOISHI_NORETURN static inline void koishi_entry(koishi_coroutine_t *co) {
+static inline KOISHI_NORETURN void koishi_entry(koishi_coroutine_t *co) {
 	co->userdata = co->entry(co->userdata);
 	koishi_return_to_caller(co, KOISHI_DEAD);
 	KOISHI_UNREACHABLE;

--- a/src/meson.build
+++ b/src/meson.build
@@ -8,6 +8,7 @@ backends = [
     'win32fiber',
     'asyncify',
     'emscripten',
+    'ucontext_e2k',
     'ucontext',
 ]
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -18,19 +18,18 @@ endforeach
 
 impl = get_option('impl')
 
-if impl == 'auto'
-    foreach i : backends
-        if get_variable('@0@_supported'.format(i))
-            impl = i
-            break
-        endif
-    endforeach
-
-    if impl == 'auto'
-        error('Unsupported platform')
-    endif
-elif not get_variable('@0@_supported'.format(impl))
+if impl != 'auto' and not get_variable('@0@_supported'.format(impl))
     error('@0@ is not supported on this platform'.format(impl))
+endif
+
+foreach i : backends
+    if impl == 'auto' and get_variable('@0@_supported'.format(i))
+        impl = i
+    endif
+endforeach
+
+if impl == 'auto'
+    error('Unsupported platform')
 endif
 
 koishi_src += get_variable('@0@_src'.format(impl))

--- a/src/ucontext/ucontext.c
+++ b/src/ucontext/ucontext.c
@@ -14,7 +14,7 @@ typedef struct uctx_fiber {
 
 static KOISHI_THREAD_LOCAL ucontext_t co_main_uctx;
 
-KOISHI_NORETURN static void co_entry(void) {
+static KOISHI_NORETURN void co_entry(void) {
 	koishi_entry(co_current);
 }
 

--- a/src/ucontext_e2k/meson.build
+++ b/src/ucontext_e2k/meson.build
@@ -1,0 +1,16 @@
+
+ucontext_e2k_supported = true
+
+# We could check here for ucontext_t in ucontext.h,
+# but due to compiler bug, we can't do this for now
+
+foreach fun : ['getcontext', 'makecontext_e2k', 'swapcontext', 'freecontext_e2k']
+    if not cc.has_function(fun, args : feature_args)
+        ucontext_e2k_supported = false
+    endif
+endforeach
+
+ucontext_e2k_src = files('ucontext_e2k.c')
+ucontext_e2k_args = []
+ucontext_e2k_external_args = []
+ucontext_e2k_external_link_args = []

--- a/src/ucontext_e2k/ucontext_e2k.c
+++ b/src/ucontext_e2k/ucontext_e2k.c
@@ -14,7 +14,7 @@ typedef struct uctx_fiber {
 
 static KOISHI_THREAD_LOCAL ucontext_t co_main_uctx;
 
-KOISHI_NORETURN static void co_entry(void) {
+static KOISHI_NORETURN void co_entry(void) {
 	koishi_entry(co_current);
 }
 

--- a/src/ucontext_e2k/ucontext_e2k.c
+++ b/src/ucontext_e2k/ucontext_e2k.c
@@ -1,0 +1,60 @@
+
+#include <koishi.h>
+#include <ucontext.h>
+#include <assert.h>
+#include <stdlib.h>
+#include "../stack_alloc.h"
+
+typedef struct uctx_fiber {
+	ucontext_t *uctx;
+	koishi_entrypoint_t entry;
+} koishi_fiber_t;
+
+#include "../fiber.h"
+
+static KOISHI_THREAD_LOCAL ucontext_t co_main_uctx;
+
+KOISHI_NORETURN static void co_entry(void) {
+	koishi_entry(co_current);
+}
+
+static void koishi_fiber_init(koishi_fiber_t *fiber, size_t min_stack_size) {
+	ucontext_t *uctx = calloc(1, sizeof(*uctx));
+	getcontext(uctx);
+	uctx->uc_stack.ss_sp = alloc_stack(min_stack_size, &uctx->uc_stack.ss_size);
+	// TODO: makecontext_e2k() could fail, but for now we don't expect that
+	makecontext_e2k(uctx, co_entry, 0);
+	fiber->uctx = uctx;
+}
+
+static void koishi_fiber_recycle(koishi_fiber_t *fiber) {
+	freecontext_e2k(fiber->uctx);
+	// TODO: makecontext_e2k() could fail, but for now we don't expect that
+	makecontext_e2k(fiber->uctx, co_entry, 0);
+}
+
+static void koishi_fiber_swap(koishi_fiber_t *from, koishi_fiber_t *to) {
+	swapcontext(from->uctx, to->uctx);
+}
+
+static void koishi_fiber_init_main(koishi_fiber_t *fiber) {
+	fiber->uctx = &co_main_uctx;
+	getcontext(&co_main_uctx);
+}
+
+static void koishi_fiber_deinit(koishi_fiber_t *fiber) {
+	if(fiber->uctx) {
+		if(fiber->uctx->uc_stack.ss_sp) {
+			free_stack(fiber->uctx->uc_stack.ss_sp, fiber->uctx->uc_stack.ss_size);
+		}
+
+		freecontext_e2k(fiber->uctx);
+		free(fiber->uctx);
+		fiber->uctx = NULL;
+	}
+}
+
+KOISHI_API void *koishi_get_stack(koishi_coroutine_t *co, size_t *stack_size) {
+	if(stack_size) *stack_size = co->fiber.uctx->uc_stack.ss_size;
+	return co->fiber.uctx->uc_stack.ss_sp;
+}

--- a/src/win32fiber/win32fiber.c
+++ b/src/win32fiber/win32fiber.c
@@ -12,7 +12,7 @@ typedef struct win32_fiber {
 
 #include "../fiber.h"
 
-KOISHI_NORETURN static void __stdcall fiber_entry(void *data) {
+static KOISHI_NORETURN void __stdcall fiber_entry(void *data) {
 	koishi_entry(KOISHI_FIBER_TO_COROUTINE(data));
 }
 


### PR DESCRIPTION
Added ucontext_e2k implementation, so koishi now supports building and running on Elbrus (e2k) architecture.
Also fixed come minor things, like warnings raised by elbrus compiler and minimum required meson version.