### PR TITLE
stack_alloc: use MAP_STACK when available

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -57,6 +57,12 @@ if cc.has_function('mmap', args : feature_args)
     elif cc.has_header_symbol('sys/mman.h', 'MAP_ANON', args : feature_args)
         koishi_args += ['-DKOISHI_HAVE_MMAP', '-DKOISHI_MAP_ANONYMOUS=MAP_ANON']
     endif
+
+    if cc.has_header_symbol('sys/mman.h', 'MAP_STACK', args : feature_args)
+        koishi_args += ['-DKOISHI_MAP_STACK=MAP_STACK']
+    else
+        koishi_args += ['-DKOISHI_MAP_STACK=0']
+    endif
 endif
 
 can_get_page_size = false

--- a/src/stack_alloc.c
+++ b/src/stack_alloc.c
@@ -39,7 +39,7 @@ static inline void *alloc_stack_mem(size_t size) {
 #if defined KOISHI_HAVE_WIN32API
 	return VirtualAlloc(NULL, size, MEM_COMMIT, PAGE_READWRITE);
 #elif defined KOISHI_HAVE_MMAP
-	return mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | KOISHI_MAP_ANONYMOUS, -1, 0);
+	return mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | KOISHI_MAP_STACK | KOISHI_MAP_ANONYMOUS , -1, 0);
 #elif defined KOISHI_HAVE_ALIGNED_ALLOC
 	return aligned_alloc(koishi_util_page_size(), size);
 #elif defined KOISHI_HAVE_POSIX_MEMALIGN


### PR DESCRIPTION
Needed on OpenBSD for allocating mappings used as stack.

see https://github.com/taisei-project/taisei/issues/372