### PR TITLE
Add a boost.context call/cc backend

### DIFF
--- a/include/koishi.h
+++ b/include/koishi.h
@@ -113,7 +113,7 @@ typedef struct koishi_coroutine {
 	 * @brief Private data reserved for the implementation. Don't mess with it.
 	 * @private
 	 */
-	void *_private[8];
+	void *_private[16];
 #ifdef BUILDING_KOISHI
 };
 #else

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -5,6 +5,7 @@ option(
         'auto',
         'fcontext',
         'boost_fcontext',
+        'boost_callcc',
         'win32fiber',
         'emscripten',
         'ucontext_e2k',

--- a/src/boost_callcc/boost_callcc.cc
+++ b/src/boost_callcc/boost_callcc.cc
@@ -1,0 +1,115 @@
+
+#include <koishi.h>
+#include <string.h>
+
+extern "C" {
+	#include "../stack_alloc.h"
+}
+
+#include <boost/context/continuation.hpp>
+namespace bctx = boost::context;
+
+typedef struct boost_fiber {
+	bctx::continuation cc;
+	struct boost_fiber *from;
+	struct boost_fiber *next;
+	char *stack;
+	size_t stack_size;
+} koishi_fiber_t;
+
+#include "../fiber.h"
+
+struct fake_allocator {
+	bctx::stack_context sctx = {};
+
+	fake_allocator(void *sp, size_t size) noexcept {
+		sctx.sp = (char*)sp + size;
+		sctx.size = size;
+	}
+
+	bctx::stack_context allocate() { return sctx; }
+	void deallocate(bctx::stack_context&) noexcept { }
+};
+
+static void koishi_fiber_init_callcc(koishi_fiber_t *fiber) {
+	fiber->from = nullptr;
+	fiber->next = nullptr;
+	new (&fiber->cc) bctx::continuation();
+
+	fiber->from = &koishi_active()->fiber;
+	fiber->cc = bctx::callcc(std::allocator_arg, fake_allocator(fiber->stack, fiber->stack_size),
+		[fiber](bctx::continuation && c) {
+			c = c.resume();
+			fiber->from->cc = std::move(c);
+
+			auto co = reinterpret_cast<koishi_coroutine_t*>(fiber);
+			co->userdata = co->entry(co->userdata);
+
+			koishi_return_to_caller(co, KOISHI_DEAD);
+
+			KOISHI_UNREACHABLE;
+			return bctx::continuation();
+		}
+	);
+}
+
+static void koishi_fiber_init(koishi_fiber_t *fiber, size_t min_stack_size) {
+	fiber->stack = (char*)alloc_stack(min_stack_size, &fiber->stack_size);
+	koishi_fiber_init_callcc(fiber);
+}
+
+static void koishi_fiber_init_main(koishi_fiber_t *fiber) {
+	new (&fiber->cc) bctx::continuation();
+	fiber->next = fiber;
+}
+
+static void koishi_fiber_recycle(koishi_fiber_t *fiber) {
+	fiber->cc.~continuation();
+	koishi_fiber_init_callcc(fiber);
+}
+
+static void koishi_fiber_deinit(koishi_fiber_t *fiber) {
+	fiber->cc.~continuation();
+
+	if(fiber->stack) {
+		free_stack(fiber->stack, fiber->stack_size);
+		fiber->stack = nullptr;
+	}
+}
+
+static void do_jump(koishi_fiber_t *from, koishi_fiber_t *to) {
+	to->from = from;
+	to->cc = to->cc.resume();
+}
+
+// TODO: Figure out how to avoid this stupid hack.
+// The resume-from-another test fails without this.
+static void stupid_trampoline(koishi_fiber_t *main) {
+	for(;;) {
+		auto next = main->next;
+
+		if(next == main) {
+			break;
+		}
+
+		main->next = main;
+		do_jump(main, next);
+	}
+}
+
+static void koishi_fiber_swap(koishi_fiber_t *from, koishi_fiber_t *to) {
+	auto main_fiber = &co_main.fiber;
+
+	if(main_fiber == from) {
+		do_jump(from, to);
+		stupid_trampoline(main_fiber);
+	} else {
+		main_fiber->next = to;
+		do_jump(from, main_fiber);
+	}
+}
+
+KOISHI_API void *koishi_get_stack(koishi_coroutine_t *co, size_t *stack_size) {
+	if(stack_size) *stack_size = co->fiber.stack_size;
+	return co->fiber.stack;
+}

--- a/src/boost_callcc/meson.build
+++ b/src/boost_callcc/meson.build
@@ -1,0 +1,20 @@
+
+boost_callcc_supported = false
+
+if not add_languages('cpp', required : false)
+    subdir_done()
+endif
+
+boostctx_dep = dependency('boost', modules : ['context'], required : false)
+
+if not boostctx_dep.found()
+    subdir_done()
+endif
+
+boost_callcc_supported = true
+boost_callcc_src = files('boost_callcc.cc')
+boost_callcc_deps = [boostctx_dep]
+boost_callcc_args = []
+boost_callcc_external_args = []
+boost_callcc_external_link_args = []
+

--- a/src/meson.build
+++ b/src/meson.build
@@ -8,6 +8,7 @@ koishi_deps = []
 backends = [
     'fcontext',
     'boost_fcontext',
+    'boost_callcc',
     'win32fiber',
     'emscripten',
     'ucontext_e2k',


### PR DESCRIPTION
This is a backend that uses the high-level call/cc C++ API from boost.context. This should in theory support CET (shadow stacks). It's an attempt to address #6  until CET support is added to other backends, though in retrospect just doing that would've probably been easier. But the more backends the merrier, right?

Seems to work ok for the most part on my machine, but has some issues:

* C++ exceptions are required; it's an implementation detail of the API.
* Taisei crashes on exit, probably from a bogus stack unwind forced in a continuation destructor somewhere. This happens pretty late in the shutdown sequence, so the game still saves the config and progress files.
* Performance is slightly behind pure `fcontext`, but not significantly.
* Switches from one coroutine (i.e. non-main) context into another are implemented by a stupid trampoline jump from the main context. This is the only way I found to pass the new resume-from-another test (required for Taisei to work), but it's clearly a suboptimal solution.
* Not tested with threads at all. Doesn't matter for Taisei.
* ASan and valgrind aren't supported yet, but that should be easy enough to fix.